### PR TITLE
fix: text color in light mode

### DIFF
--- a/src/components/markdown-renderer.tsx
+++ b/src/components/markdown-renderer.tsx
@@ -8,7 +8,7 @@ interface MarkdownRendererProps {
 
 export function MarkdownRenderer({ content }: MarkdownRendererProps) {
   return (
-    <article className="prose prose-slate max-w-none dark:prose-invert text-white dark:text-gray-300 hyphens-auto">
+    <article className="prose prose-slate max-w-none dark:prose-invert text-gray-600 dark:text-gray-300 hyphens-auto">
       <Markdown>{content}</Markdown>
     </article>
   );


### PR DESCRIPTION
Before : **text invisible in light mode**

<img width="735" height="571" alt="Screenshot 2025-08-11 at 00 49 55" src="https://github.com/user-attachments/assets/e99b87c8-815a-4775-89a3-6e06e0ff3ae3" />

---

After: **text visible in light mode**

<img width="824" height="732" alt="Screenshot 2025-08-11 at 00 53 20" src="https://github.com/user-attachments/assets/fef55b5c-0c04-4962-87d5-68018d54098d" />
